### PR TITLE
feat(repo): Add unpkg refs for cytoscape

### DIFF
--- a/main.html
+++ b/main.html
@@ -13,7 +13,8 @@
         <div id ="graph_display"></div>
 
         <!-- <Libraries> -->
-        <script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.23.0/cytoscape.min.js"></script>
+        <script src="https://unpkg.com/cytoscape@3.23.0/dist/cytoscape.min.js"></script>
+        <script src="https://unpkg.com/cytoscape-sbgn-stylesheet@4.0.2/build/bundle.js"></script>
 
         <!-- <Scripts> -->
         <script src="src/graph.js"></script> <!-- Structure that stores the graph data -->


### PR DESCRIPTION
Voici le même fix qu'[ici](https://github.com/Bordeterre/monkeypox_metabolism/pull/11) pour votre branche main, j'ai pas pu tester que ça résolvais vos imports mais au moins c'est des imports sans npm puisque visiblement le cremi a un npm de l'âge de pierre. Quand je dis que je n'ai pas pû tester c'est que le seul bouton de votre page ne fonctionne ni avec Chromium, ni avec Firefox donc j'ai juste modifié les imports et vérifié qu'il n'y avait pas de crash dans la console. Enjoy

@Bordeterre @Noiselis @Bluwen @TexierLouis  @LeaChabot 